### PR TITLE
Fixed BitFont sample

### DIFF
--- a/examples/BitFont/BitFont.ino
+++ b/examples/BitFont/BitFont.ino
@@ -118,8 +118,8 @@ void loop() {
   else 
     vga.noTone();
   vga.clear(11);
-  vga.print((byte*)fnt_nanofont_data, FNT_NANOFONT_SYMBOLS_COUNT, FNT_NANOFONT_HEIGHT, 3, 1, str0, x, 10, 1);
-  vga.print((byte*)fnt_nanofont_data, FNT_NANOFONT_SYMBOLS_COUNT, FNT_NANOFONT_HEIGHT, 3, 1, str1, x, 17, 2);
+  vga.printPROGMEM((byte*)fnt_nanofont_data, FNT_NANOFONT_SYMBOLS_COUNT, FNT_NANOFONT_HEIGHT, 3, 1, str0, x, 10, 1);
+  vga.printPROGMEM((byte*)fnt_nanofont_data, FNT_NANOFONT_SYMBOLS_COUNT, FNT_NANOFONT_HEIGHT, 3, 1, str1, x, 17, 2);
   x++;
   if (x==VGAX_WIDTH)
     x=-VGAX_WIDTH;


### PR DESCRIPTION
There's no `vga.print()`. 
`vga.printPROGMEM()` seems to be what's intended here. Tested, works.
