### PR TITLE
Use all colors in random pixel example and fix vtimer overflowing

### DIFF
--- a/VGAX.cpp
+++ b/VGAX.cpp
@@ -35,7 +35,7 @@ You can modify this value to center the framebuffer vertically, or not*/
 #endif
 
 static byte afreq, afreq0;
-unsigned vtimer;
+unsigned long vtimer;
 static byte aline, rlinecnt;
 static byte vskip;
 byte vgaxfb[VGAX_HEIGHT*VGAX_BWIDTH];

--- a/VGAX.h
+++ b/VGAX.h
@@ -52,7 +52,7 @@ HERE you can find some inline documentation about the VGAX library class
 extern byte vgaxfb[VGAX_HEIGHT*VGAX_BWIDTH];
 
 //clock replacement. this is increment in the VSYNC interrupt, so run at 60Hz
-extern unsigned vtimer;
+extern unsigned long vtimer;
 
 //VGAX class. This is a static class. Multiple instances will not work
 class VGAX {
@@ -224,7 +224,7 @@ public:
    * millis()
    *    return the number of milliseconds ellapsed
    */
-  static inline unsigned millis() {
+  static inline unsigned long millis() {
     return vtimer*16;
   }
   /*

--- a/examples/RandomPixels/RandomPixels.ino
+++ b/examples/RandomPixels/RandomPixels.ino
@@ -9,5 +9,5 @@ void setup() {
 void loop() {
   static unsigned cnt;
   cnt++;
-  vga.putpixel(rand()%VGAX_WIDTH, rand()%VGAX_HEIGHT, cnt%3);
+  vga.putpixel(rand()%VGAX_WIDTH, rand()%VGAX_HEIGHT, cnt%4);
 }


### PR DESCRIPTION
Hello,

the vtimer almost always overflows during the calculation in the micros() function, because the calculation is done with unsigned / 16-bit precision and then the result is converted to unsigned long / 32-bit precision. 
Overflow also occurs in the millis() function after ~65 seconds. 
Both can be easily fixed by using unsigned long instead of unsigned for vtimer.

Best regards
